### PR TITLE
Pin GitHub Actions to SHA hashes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Clojure
-        uses: DeLaGuardo/setup-clojure@13.0
+        uses: DeLaGuardo/setup-clojure@94d767dbb80ae5c637d0f1ad70b75fa2b00495cd # 13.0
         with:
           cli: latest
 


### PR DESCRIPTION
## Summary
- Pins all GitHub Action references to specific commit SHAs for supply chain security
- Preserves original version tags as comments for readability
- No functional changes - actions resolve to the same versions

## Context
This is part of an org-wide audit to improve GitHub Actions supply chain security.

Generated with Claude Code